### PR TITLE
perf: cancel in progress runs of ember asset size action, when new commit is added

### DIFF
--- a/.github/workflows/ember-compare-asset-sizes.yml
+++ b/.github/workflows/ember-compare-asset-sizes.yml
@@ -10,6 +10,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# Cancels in-progress runs of this action when new commits are added to the branch, running only the latest.
+# See: https://stackoverflow.com/a/67939898
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensure that this action is cancelled when a new commit comes in on the branch - no point running it for a prior commit.

This action can be a little bit intensive since it builds the ember prod bundle twice.